### PR TITLE
PHP 8.1 Support Adding Return Type Attribute for ArrayAccess notices

### DIFF
--- a/src/Config/Repository.php
+++ b/src/Config/Repository.php
@@ -274,6 +274,7 @@ class Repository extends NamespacedItemResolver implements ArrayAccess, ConfigCo
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return $this->has($key);
@@ -286,6 +287,7 @@ class Repository extends NamespacedItemResolver implements ArrayAccess, ConfigCo
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key);
@@ -299,6 +301,7 @@ class Repository extends NamespacedItemResolver implements ArrayAccess, ConfigCo
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->set($key, $value);
@@ -311,6 +314,7 @@ class Repository extends NamespacedItemResolver implements ArrayAccess, ConfigCo
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         $this->set($key, null);


### PR DESCRIPTION
This PR fixes the following Deprecation Notices for PHP 8.1:

- Deprecated: Return type of Orchestra\Config\Repository::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../vendor/orchestra/config/Repository.php on line 277

- Deprecated: Return type of Orchestra\Config\Repository::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../vendor/orchestra/config/Repository.php on line 289
 
- Deprecated: Return type of Orchestra\Config\Repository::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../vendor/orchestra/config/Repository.php on line 302
 
- Deprecated: Return type of Orchestra\Config\Repository::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in .../vendor/orchestra/config/Repository.php on line 314